### PR TITLE
Step4

### DIFF
--- a/src/main/java/com/jongmin/mystorage/controller/api/StorageInfoApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/StorageInfoApiController.java
@@ -1,0 +1,22 @@
+package com.jongmin.mystorage.controller.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jongmin.mystorage.service.response.StorageInfoResponse;
+import com.jongmin.mystorage.service.storage.StorageInfoService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class StorageInfoApiController {
+
+	private final StorageInfoService storageInfoService;
+
+	@GetMapping("/api/storageInfo")
+	public StorageInfoResponse getStorageInfo(@RequestHeader("ownerName") String ownerName) {
+		return storageInfoService.getStorageInfo(ownerName);
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/model/BaseEntity.java
+++ b/src/main/java/com/jongmin/mystorage/model/BaseEntity.java
@@ -28,6 +28,6 @@ public abstract class BaseEntity {
 
 	@LastModifiedDate
 	@Column(nullable = false)
-	private LocalDateTime updatedAt;
+	protected LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/jongmin/mystorage/model/MyFolder.java
+++ b/src/main/java/com/jongmin/mystorage/model/MyFolder.java
@@ -1,5 +1,6 @@
 package com.jongmin.mystorage.model;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -73,6 +74,11 @@ public class MyFolder extends FileSystemItem {
 	public MyFolder replacePath(String from, String to) {
 		this.parentPath = this.getParentPath().replaceFirst(from, to);
 		this.fullPath = this.parentPath + "/" + this.folderName;
+		return this;
+	}
+
+	public MyFolder setUpdateAt(LocalDateTime time) {
+		this.updatedAt = time;
 		return this;
 	}
 }

--- a/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
+++ b/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
@@ -24,6 +24,9 @@ public class StorageInfo extends BaseEntity {
 
 	public StorageInfo(String ownerName) {
 		this.ownerName = ownerName;
+		this.size = 0L;
+		this.fileCount = 0L;
+		this.folderCount = 0L;
 	}
 
 	public void setSize(Long size) {

--- a/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
+++ b/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
@@ -1,5 +1,7 @@
 package com.jongmin.mystorage.model;
 
+import com.jongmin.mystorage.model.value.GradeMaxSize;
+
 import jakarta.persistence.Entity;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +15,7 @@ public class StorageInfo extends BaseEntity {
 	private Long size;
 	private Long fileCount;
 	private Long folderCount;
+	private Long maxSize;
 
 	@Builder
 	public StorageInfo(String ownerName, Long size, Long fileCount, Long folderCount) {
@@ -20,6 +23,7 @@ public class StorageInfo extends BaseEntity {
 		this.size = size;
 		this.fileCount = fileCount;
 		this.folderCount = folderCount;
+		this.maxSize = GradeMaxSize.NORMAL;
 	}
 
 	public StorageInfo(String ownerName) {

--- a/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
+++ b/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
@@ -18,12 +18,12 @@ public class StorageInfo extends BaseEntity {
 	private Long maxSize;
 
 	@Builder
-	public StorageInfo(String ownerName, Long size, Long fileCount, Long folderCount) {
+	public StorageInfo(String ownerName, Long size, Long fileCount, Long folderCount, Long maxSize) {
 		this.ownerName = ownerName;
 		this.size = size;
 		this.fileCount = fileCount;
 		this.folderCount = folderCount;
-		this.maxSize = GradeMaxSize.NORMAL;
+		this.maxSize = maxSize;
 	}
 
 	public StorageInfo(String ownerName) {
@@ -31,6 +31,7 @@ public class StorageInfo extends BaseEntity {
 		this.size = 0L;
 		this.fileCount = 0L;
 		this.folderCount = 0L;
+		this.maxSize = GradeMaxSize.NORMAL;
 	}
 
 	public void setSize(Long size) {

--- a/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
+++ b/src/main/java/com/jongmin/mystorage/model/StorageInfo.java
@@ -1,0 +1,40 @@
+package com.jongmin.mystorage.model;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class StorageInfo extends BaseEntity {
+	private String ownerName;
+	private Long size;
+	private Long fileCount;
+	private Long folderCount;
+
+	@Builder
+	public StorageInfo(String ownerName, Long size, Long fileCount, Long folderCount) {
+		this.ownerName = ownerName;
+		this.size = size;
+		this.fileCount = fileCount;
+		this.folderCount = folderCount;
+	}
+
+	public StorageInfo(String ownerName) {
+		this.ownerName = ownerName;
+	}
+
+	public void setSize(Long size) {
+		this.size = size;
+	}
+
+	public void setFileCount(Long fileCount) {
+		this.fileCount = fileCount;
+	}
+
+	public void setFolderCount(Long folderCount) {
+		this.folderCount = folderCount;
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/model/value/GradeMaxSize.java
+++ b/src/main/java/com/jongmin/mystorage/model/value/GradeMaxSize.java
@@ -1,0 +1,7 @@
+package com.jongmin.mystorage.model.value;
+
+public class GradeMaxSize {
+	public static Long NORMAL = 2147483648L;
+	public static Long VIP = 2147483648L * 2;
+	public static Long VVIP = 2147483648L * 4;
+}

--- a/src/main/java/com/jongmin/mystorage/repository/CountAndSum.java
+++ b/src/main/java/com/jongmin/mystorage/repository/CountAndSum.java
@@ -1,0 +1,14 @@
+package com.jongmin.mystorage.repository;
+
+import lombok.Getter;
+
+@Getter
+public class CountAndSum {
+	private Long count;
+	private Long totalSize;
+
+	public CountAndSum(Long count, Long totalSize) {
+		this.count = count;
+		this.totalSize = totalSize;
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/repository/FileRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/FileRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.jongmin.mystorage.model.MyFile;
@@ -22,4 +24,10 @@ public interface FileRepository extends JpaRepository<MyFile, Long> {
 	Optional<MyFile> findByFileName(String fileName);
 
 	List<MyFile> findByOwnerNameAndFullPathStartingWith(String ownerName, String fullPath);
+
+	@Query("SELECT new com.jongmin.mystorage.repository.CountAndSum(COUNT(m), COALESCE(SUM(m.size), 0))"
+		+ "FROM MyFile m "
+		+ "WHERE m.ownerName = :ownerName AND m.fullPath LIKE CONCAT(:fullPath, '%') AND m.status = SAVED")
+	CountAndSum countAndSumByOwnerNameAndFullPath(@Param("ownerName") String ownerName,
+											@Param("fullPath") String fullPath);
 }

--- a/src/main/java/com/jongmin/mystorage/repository/FolderRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/FolderRepository.java
@@ -24,4 +24,6 @@ public interface FolderRepository extends JpaRepository<MyFolder, Long> {
 		Long id, FileItemStatus status);
 
 	List<MyFolder> findByOwnerNameAndFullPathStartingWith(String ownerName, String fullPath);
+
+	Long countByOwnerNameAndFullPathStartingWithAndStatus(String ownerName, String fullPath, FileItemStatus status);
 }

--- a/src/main/java/com/jongmin/mystorage/repository/StorageInfoRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/StorageInfoRepository.java
@@ -1,0 +1,13 @@
+package com.jongmin.mystorage.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.jongmin.mystorage.model.StorageInfo;
+
+@Repository
+public interface StorageInfoRepository extends JpaRepository<StorageInfo, Long> {
+	Optional<StorageInfo> findByOwnerName(String ownerName);
+}

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -62,6 +62,7 @@ public class FileService {
 		// 파일 상태를 확인하고 삭제하는 과정이 atomic하게 진행될 수 있도록 추후에 수정이 필요합니다.
 		// 파일을 다운로드 받는 사용자가 있는 경우 역시 고려되어야 합니다.
 		MyFile checkedFile = fileRepositoryUtils.getFileByUuidWithSavedStatus(ownerName, fileUuid);
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
 
 		if (fileIoUtils.fileNotExists(checkedFile)) {
 			throw new FileNotInFileSystemException("파일이 디스크 상에 존재하지 않습니다.");
@@ -69,6 +70,7 @@ public class FileService {
 		fileRepositoryUtils.deleteFile(checkedFile);
 		fileIoUtils.deleteFile(checkedFile);
 		checkedFile.getParentFolder().setUpdateAt(LocalDateTime.now());
+		storageInfoRepositoryUtils.deleteFile(storageInfo, checkedFile);
 
 		return new StringResponse("요청한 파일에 대한 삭제가 성공적으로 진행되었습니다.");
 	}

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -42,11 +42,14 @@ public class FileService {
 			throw new FileAlreadyExistException("이미 동일한 이름의 파일이 존재합니다.");
 		}
 
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
+		if (storageInfo.getSize() + requestDto.getMultipartFile().getSize() >  storageInfo.getMaxSize()) {
+			throw new FileAlreadyExistException("자신의 스토리지 용량을 초과하여 저장할 수 없습니다.");
+		}
+
 		fileIoUtils.save(requestDto.getMultipartFile(), myFileEntity);
 		fileRepository.save(myFileEntity);
 		parentFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
-
-		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
 		storageInfoRepositoryUtils.addFile(storageInfo, myFileEntity);
 
 		return FileResponse.fromMyFile(myFileEntity);

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -44,7 +44,7 @@ public class FileService {
 
 		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
 		if (storageInfo.getSize() + requestDto.getMultipartFile().getSize() >  storageInfo.getMaxSize()) {
-			throw new FileAlreadyExistException("자신의 스토리지 용량을 초과하여 저장할 수 없습니다.");
+			throw new RuntimeException("자신의 스토리지 용량을 초과하여 저장할 수 없습니다.");
 		}
 
 		fileIoUtils.save(requestDto.getMultipartFile(), myFileEntity);

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -11,12 +11,14 @@ import com.jongmin.mystorage.exception.FileAlreadyExistException;
 import com.jongmin.mystorage.exception.FileNotInFileSystemException;
 import com.jongmin.mystorage.model.MyFile;
 import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.StorageInfo;
 import com.jongmin.mystorage.repository.FileRepository;
 import com.jongmin.mystorage.service.response.FileResponse;
 import com.jongmin.mystorage.service.response.StringResponse;
 import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class FileService {
 	private final FolderRepositoryUtils folderRepositoryUtils;
 	private final FileRepositoryUtils fileRepositoryUtils;
 	private final FileIoUtils fileIoUtils;
+	private final StorageInfoRepositoryUtils storageInfoRepositoryUtils;
 
 	public FileResponse uploadFile(String ownerName, UploadFileRequestDto requestDto) {
 		MyFolder parentFolder = folderRepositoryUtils.getFolderByUuid(requestDto.getFolderUuid());
@@ -42,6 +45,9 @@ public class FileService {
 		fileIoUtils.save(requestDto.getMultipartFile(), myFileEntity);
 		fileRepository.save(myFileEntity);
 		parentFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
+
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
+		storageInfoRepositoryUtils.addFile(storageInfo, myFileEntity);
 
 		return FileResponse.fromMyFile(myFileEntity);
 	}

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -1,5 +1,6 @@
 package com.jongmin.mystorage.service.file;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.core.io.Resource;
@@ -40,6 +41,8 @@ public class FileService {
 
 		fileIoUtils.save(requestDto.getMultipartFile(), myFileEntity);
 		fileRepository.save(myFileEntity);
+		parentFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
+
 		return FileResponse.fromMyFile(myFileEntity);
 	}
 
@@ -59,6 +62,7 @@ public class FileService {
 		}
 		fileRepositoryUtils.deleteFile(checkedFile);
 		fileIoUtils.deleteFile(checkedFile);
+		checkedFile.getParentFolder().setUpdateAt(LocalDateTime.now());
 
 		return new StringResponse("요청한 파일에 대한 삭제가 성공적으로 진행되었습니다.");
 	}
@@ -76,6 +80,7 @@ public class FileService {
 	@Transactional
 	public FileResponse moveFile(String ownerName, UUID fileUuid, UUID destFolderUuid) {
 		MyFile file = fileRepositoryUtils.getFileByUuidWithSavedStatus(ownerName, fileUuid);
+		MyFolder beforeFolder = file.getParentFolder();
 		MyFolder destFolder = folderRepositoryUtils.getFolderByUuidWithSavedStatus(ownerName, destFolderUuid);
 
 		if (fileRepositoryUtils.sameFileNameExistsInFolder(file, destFolder)) {
@@ -83,6 +88,8 @@ public class FileService {
 		} else {
 			file.move(destFolder);
 		}
+		beforeFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
+		destFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
 
 		return FileResponse.fromMyFile(file);
 	}

--- a/src/main/java/com/jongmin/mystorage/service/folder/FolderService.java
+++ b/src/main/java/com/jongmin/mystorage/service/folder/FolderService.java
@@ -93,6 +93,7 @@ public class FolderService {
 	public StringResponse deleteFolder(String ownerName, UUID folderId) {
 
 		MyFolder myFolder = folderRepositoryUtils.getFolderByUuidWithSavedStatus(ownerName, folderId);
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
 		String fullPath = myFolder.getFullPath();
 
 		List<MyFile> files = fileRepository.findByOwnerNameAndFullPathStartingWith(ownerName, fullPath);
@@ -103,6 +104,7 @@ public class FolderService {
 		folders.stream().forEach(MyFolder::deleteFolder);
 
 		myFolder.getParentFolder().setUpdateAt(LocalDateTime.now());
+		storageInfoRepositoryUtils.deleteFolder(storageInfo);
 
 		return new StringResponse("폴더 삭제가 완료되었습니다");
 	}

--- a/src/main/java/com/jongmin/mystorage/service/folder/FolderService.java
+++ b/src/main/java/com/jongmin/mystorage/service/folder/FolderService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import com.jongmin.mystorage.exception.FileAlreadyExistException;
 import com.jongmin.mystorage.model.MyFile;
 import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.StorageInfo;
 import com.jongmin.mystorage.repository.FileRepository;
 import com.jongmin.mystorage.repository.FolderRepository;
 import com.jongmin.mystorage.service.response.FolderInfoResponse;
@@ -16,6 +17,7 @@ import com.jongmin.mystorage.service.response.FolderResponse;
 import com.jongmin.mystorage.service.response.StringResponse;
 import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,7 @@ public class FolderService {
 
 	private final FileRepository fileRepository;
 	private final FileIoUtils fileIoUtils;
+	private final StorageInfoRepositoryUtils storageInfoRepositoryUtils;
 
 	@Transactional
 	public FolderResponse createFolder(String ownerName, String folderName, UUID parentFolderUuid) {
@@ -51,6 +54,9 @@ public class FolderService {
 
 		MyFolder createdFolder = folderRepositoryUtils.createAndPersistFolder(ownerName, folderName, parentFolder);
 		parentFolder.setUpdateAt(LocalDateTime.now());
+
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
+		storageInfoRepositoryUtils.addFolder(storageInfo);
 
 		return FolderResponse.fromMyFolder(createdFolder);
 	}

--- a/src/main/java/com/jongmin/mystorage/service/response/FolderInfoResponse.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/FolderInfoResponse.java
@@ -20,10 +20,14 @@ public class FolderInfoResponse {
 	private LocalDateTime updatedAt;
 	private List<FolderResponse> folders;
 	private List<FileResponse> files;
+	private Long folderCount;
+	private Long fileCount;
+	private Long size;
 
 	@Builder
 	public FolderInfoResponse(String folderName, UUID uuid, String fullPath, LocalDateTime createdAt,
-		LocalDateTime updatedAt, List<FolderResponse> folders, List<FileResponse> files) {
+		LocalDateTime updatedAt, List<FolderResponse> folders, List<FileResponse> files, Long folderCount,
+		Long fileCount, Long size) {
 		this.folderName = folderName;
 		this.uuid = uuid;
 		this.fullPath = fullPath;
@@ -31,6 +35,9 @@ public class FolderInfoResponse {
 		this.updatedAt = updatedAt;
 		this.folders = folders;
 		this.files = files;
+		this.folderCount = folderCount;
+		this.fileCount = fileCount;
+		this.size = size;
 	}
 
 	public static FolderInfoResponse fromMyFolder(MyFolder myFolder) {
@@ -58,6 +65,15 @@ public class FolderInfoResponse {
 			.folders(folders)
 			.files(files)
 			.build();
+	}
+
+	public static FolderInfoResponse fromMyFolder(MyFolder myFolder, Long folderCount, Long fileCount, Long size) {
+		FolderInfoResponse response = FolderInfoResponse.fromMyFolder(myFolder);
+		response.fileCount = fileCount;
+		response.folderCount = folderCount;
+		response.size = size;
+
+		return response;
 	}
 
 }

--- a/src/main/java/com/jongmin/mystorage/service/response/StorageInfoResponse.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/StorageInfoResponse.java
@@ -1,0 +1,32 @@
+package com.jongmin.mystorage.service.response;
+
+import com.jongmin.mystorage.model.StorageInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StorageInfoResponse {
+	private Long currentSize;
+	private Long maxSize;
+	private Long fileCount;
+	private Long folderCount;
+
+	@Builder
+	public StorageInfoResponse(Long maxSize, Long currentSize, Long fileCount, Long folderCount) {
+		this.maxSize = maxSize;
+		this.currentSize = currentSize;
+		this.fileCount = fileCount;
+		this.folderCount = folderCount;
+	}
+
+	public static StorageInfoResponse fromStorageInfo(StorageInfo storageInfo) {
+		return StorageInfoResponse.builder().maxSize(storageInfo.getMaxSize())
+			.currentSize(storageInfo.getSize())
+			.fileCount(storageInfo.getFileCount())
+			.folderCount(storageInfo.getFolderCount())
+			.build();
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/service/storage/StorageInfoService.java
+++ b/src/main/java/com/jongmin/mystorage/service/storage/StorageInfoService.java
@@ -1,0 +1,22 @@
+package com.jongmin.mystorage.service.storage;
+
+import org.springframework.stereotype.Service;
+
+import com.jongmin.mystorage.model.StorageInfo;
+import com.jongmin.mystorage.service.response.StorageInfoResponse;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StorageInfoService {
+
+	private final StorageInfoRepositoryUtils storageInfoRepositoryUtils;
+
+	public StorageInfoResponse getStorageInfo(String ownerName) {
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
+		return StorageInfoResponse.fromStorageInfo(storageInfo);
+	}
+
+}

--- a/src/main/java/com/jongmin/mystorage/utils/repositorytutils/FolderRepositoryUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/repositorytutils/FolderRepositoryUtils.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.jongmin.mystorage.exception.FileNotInDatabaseException;
 import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.StorageInfo;
 import com.jongmin.mystorage.model.enums.FileItemStatus;
 import com.jongmin.mystorage.repository.FolderRepository;
 
@@ -17,6 +18,7 @@ import lombok.AllArgsConstructor;
 public class FolderRepositoryUtils {
 
 	private final FolderRepository folderRepository;
+	public final StorageInfoRepositoryUtils storageInfoRepositoryUtils;
 
 	public MyFolder createAndPersistRootFolder(String ownerName) {
 		MyFolder root = MyFolder.createMyFolderEntity(ownerName, "", null);
@@ -40,6 +42,8 @@ public class FolderRepositoryUtils {
 		Optional<MyFolder> optional = folderRepository.findByOwnerNameAndFullPath(ownerName, "");
 		MyFolder root;
 		if (optional.isEmpty()) {
+			StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
+			storageInfoRepositoryUtils.addFolder(storageInfo);
 			root = createAndPersistRootFolder(ownerName);
 		} else {
 			root = optional.get();

--- a/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
@@ -47,4 +47,19 @@ public class StorageInfoRepositoryUtils {
 		return storageInfo;
 	}
 
+	public StorageInfo addFolder(StorageInfo storageInfo, Long count) {
+		storageInfo.setFolderCount(storageInfo.getFolderCount() + count);
+		return storageInfo;
+	}
+
+	public StorageInfo deleteFolder(StorageInfo storageInfo) {
+		storageInfo.setFolderCount(storageInfo.getFolderCount() - 1);
+		return storageInfo;
+	}
+
+	public StorageInfo deleteFile(StorageInfo storageInfo, MyFile checkedFile) {
+		storageInfo.setFolderCount(storageInfo.getFolderCount() - 1);
+		storageInfo.setSize(storageInfo.getSize() - checkedFile.getSize());
+		return storageInfo;
+	}
 }

--- a/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
@@ -1,7 +1,6 @@
 package com.jongmin.mystorage.utils.repositorytutils;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.jongmin.mystorage.model.MyFile;
 import com.jongmin.mystorage.model.StorageInfo;
@@ -58,7 +57,7 @@ public class StorageInfoRepositoryUtils {
 	}
 
 	public StorageInfo deleteFile(StorageInfo storageInfo, MyFile checkedFile) {
-		storageInfo.setFolderCount(storageInfo.getFolderCount() - 1);
+		storageInfo.setFileCount(storageInfo.getFileCount() - 1);
 		storageInfo.setSize(storageInfo.getSize() - checkedFile.getSize());
 		return storageInfo;
 	}

--- a/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/repositorytutils/StorageInfoRepositoryUtils.java
@@ -1,0 +1,50 @@
+package com.jongmin.mystorage.utils.repositorytutils;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.StorageInfo;
+import com.jongmin.mystorage.repository.StorageInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StorageInfoRepositoryUtils {
+
+	private final StorageInfoRepository storageInfoRepository;
+
+	public StorageInfo getStorageInfo(String ownerName) {
+		return storageInfoRepository.findByOwnerName(ownerName)
+			.orElseGet(() -> storageInfoRepository.save(new StorageInfo(ownerName)));
+	}
+
+	// public setter 위험 해보임 -> 같은 패키지에서만 setter 이용 가능하도록 default(package-private) 이용?
+	public StorageInfo addFile(StorageInfo storageInfo, MyFile file) {
+		storageInfo.setSize(storageInfo.getSize() + file.getSize());
+		storageInfo.setFileCount(storageInfo.getFileCount() + 1);
+		return storageInfo;
+	}
+
+	public StorageInfo addFileCount(StorageInfo storageInfo, int fileCount) {
+		storageInfo.setFileCount(storageInfo.getFileCount() + fileCount);
+		return storageInfo;
+	}
+
+	public StorageInfo addSize(StorageInfo storageInfo, Long size) {
+		storageInfo.setSize(storageInfo.getSize() + size);
+		return storageInfo;
+	}
+
+	public StorageInfo addFolderCount(StorageInfo storageInfo, Long folderCount) {
+		storageInfo.setFolderCount(storageInfo.getFolderCount() + folderCount);
+		return storageInfo;
+	}
+
+	public StorageInfo addFolder(StorageInfo storageInfo) {
+		storageInfo.setFolderCount(storageInfo.getFolderCount() + 1);
+		return storageInfo;
+	}
+
+}

--- a/src/test/java/com/jongmin/mystorage/service/FileServiceTest.java
+++ b/src/test/java/com/jongmin/mystorage/service/FileServiceTest.java
@@ -1,15 +1,11 @@
 package com.jongmin.mystorage.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.UUID;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,21 +16,23 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.jongmin.mystorage.controller.api.dto.UploadFileRequestDto;
 import com.jongmin.mystorage.exception.FileAlreadyExistException;
 import com.jongmin.mystorage.model.MyFile;
 import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.StorageInfo;
 import com.jongmin.mystorage.model.enums.FileItemStatus;
 import com.jongmin.mystorage.repository.FileRepository;
 import com.jongmin.mystorage.repository.FolderRepository;
+import com.jongmin.mystorage.repository.StorageInfoRepository;
 import com.jongmin.mystorage.service.file.FileService;
 import com.jongmin.mystorage.service.response.FileResponse;
 import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
 import com.jongmin.mystorage.utils.ioutils.FolderIolUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
 
 import jakarta.persistence.EntityManager;
 
@@ -58,6 +56,10 @@ public class FileServiceTest {
 	@Autowired
 	private FileService fileService;
 	@Autowired
+	private StorageInfoRepository storageInfoRepository;
+	@Autowired
+	private StorageInfoRepositoryUtils storageInfoRepositoryUtils;
+	@Autowired
 	private EntityManager entityManager;
 
 	@AfterEach
@@ -69,144 +71,119 @@ public class FileServiceTest {
 	@DisplayName("uploadFile : 정상 흐름")
 	@Test
 	@Transactional
-	public void uploadFile() throws IOException {
-		Path path = Paths.get("src/test/resources/test.txt");
-		byte[] content = Files.readAllBytes(path);
+	public void uploadFileTest() {
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
 
-		UUID folderUuid = UUID.fromString("12345678-1111-1234-1234-123456789abc");
-		String ownerName = "testOwner";
-
-		MyFolder testFolderEntity = MyFolder.createMyFolderEntity(ownerName, "testFolder", null, folderUuid);
-		folderIolUtils.createPhysicalFolder(ownerName, folderUuid);
-		folderRepository.save(testFolderEntity);
-
-		MockMultipartFile mockFile = new MockMultipartFile("test.txt", "test.txt", "text/plain", content);
-		UploadFileRequestDto requestDto = new UploadFileRequestDto(mockFile, folderUuid);
+		MockMultipartFile mockFile = new MockMultipartFile("test.txt", "test.txt", "text/plain", new byte[] {1});
+		UploadFileRequestDto requestDto = new UploadFileRequestDto(mockFile, hello.getUuid());
 
 		// when
 		FileResponse fileResponse = fileService.uploadFile("testOwner", requestDto);
 
 		// then
-		Assertions.assertThat(fileResponse.getFileName()).isEqualTo(mockFile.getOriginalFilename());
-		Assertions.assertThat(fileResponse.getSize()).isEqualTo(requestDto.getMultipartFile().getSize());
-		Assertions.assertThat(fileResponse.getFullPath())
-			.isEqualTo(testFolderEntity.getFullPath() + "/" + mockFile.getOriginalFilename());
+		assertThat(fileResponse.getFileName()).isEqualTo(mockFile.getOriginalFilename());
+		assertThat(fileResponse.getSize()).isEqualTo(mockFile.getSize());
+		assertThat(fileResponse.getFullPath()).isEqualTo("/hello/test.txt");
 	}
 
 	@DisplayName("uploadFile : 폴더 내 동일한 파일 이름 존재 -> FileAlreadyExistException ")
 	@Test
 	@Transactional
-	public void uploadFileDuplicateNameFile() throws IOException {
+	public void uploadFileTestDuplicateNameFile() {
 		// given
-		Path path = Paths.get("src/test/resources/test.txt");
-		byte[] content = Files.readAllBytes(path);
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MockMultipartFile mockFile1 = new MockMultipartFile("test.txt", "test.txt", "text/plain", new byte[] {1});
+		MockMultipartFile mockFile2 = new MockMultipartFile("test.txt", "test.txt", "text/plain", new byte[] {12});
 
-		UUID folderUuid = UUID.fromString("12345678-1111-1234-1234-123456789abc");
-		String ownerName = "testOwner";
+		UploadFileRequestDto requestDto1 = new UploadFileRequestDto(mockFile1, hello.getUuid());
+		UploadFileRequestDto requestDto2 = new UploadFileRequestDto(mockFile2, hello.getUuid());
 
-		MyFolder testFolderEntity = MyFolder.createMyFolderEntity(ownerName, "testFolder", null, folderUuid);
-		folderIolUtils.createPhysicalFolder(ownerName, folderUuid);
-		folderRepository.save(testFolderEntity);
+		fileService.uploadFile("testOwner", requestDto1);
 
-		MockMultipartFile mockFile = new MockMultipartFile("test.txt", "test.txt", "text/plain", content);
-		UploadFileRequestDto requestDto = new UploadFileRequestDto(mockFile, folderUuid);
-
-		FileResponse fileResponse = fileService.uploadFile("testOwner", requestDto);
-
-		MockMultipartFile mockFile2 = new MockMultipartFile("test.txt", "test.txt", "text/plain", new byte[] {123});
-		UploadFileRequestDto requestDto2 = new UploadFileRequestDto(mockFile2, folderUuid);
-
-		entityManager.clear();
 		// when - then
 		FileAlreadyExistException exception = assertThrows(
 			FileAlreadyExistException.class, () -> fileService.uploadFile("testOwner", requestDto2)
 		);
-		Assertions.assertThat(exception.getMessage()).isEqualTo("이미 동일한 이름의 파일이 존재합니다.");
+		assertThat(exception.getMessage()).isEqualTo("이미 동일한 이름의 파일이 존재합니다.");
 	}
 
 	@DisplayName("readFile : 정상 흐름")
 	@Test
 	@Transactional
-	public void readFile() throws IOException {
+	public void readFileTest() {
 		// given
-		String ownerName = "testOwner";
-		UUID folderUuid = UUID.fromString("12345678-1111-1234-1234-123456789abc");
-		UUID fileUuid = UUID.fromString("12345678-2222-1234-1234-123456789abc");
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
 
-		Path path = Paths.get("src/test/resources/test.txt");
-		byte[] content = Files.readAllBytes(path);
-		MultipartFile testFile = new MockMultipartFile("test.txt", "test.txt", "text/plain", content);
-
-		MyFolder testFolderEntity = MyFolder.createMyFolderEntity(ownerName, "testFolder", null, folderUuid);
-		folderIolUtils.createPhysicalFolder(ownerName, folderUuid);
-		folderRepository.save(testFolderEntity);
-
-		MyFile testFileEntity = MyFile.createMyFileEntity(testFile, ownerName, testFolderEntity, fileUuid);
-		fileIoUtils.save(testFile, testFileEntity);
-		MyFile fileEntity = fileRepository.save(testFileEntity);
+		MockMultipartFile mockFile = new MockMultipartFile("file1.txt", "file1.txt", "text/plain", new byte[] {123});
+		MyFile file = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, file);
 
 		// when
-		FileResponse fileResponse = fileService.readFile(ownerName, fileUuid);
+		FileResponse fileResponse = fileService.readFile("testOwner", file.getUuid());
 
 		// then
-		Assertions.assertThat(fileResponse.getFileName()).isEqualTo(fileEntity.getFileName());
-		Assertions.assertThat(fileResponse.getSize()).isEqualTo(fileEntity.getSize());
-		Assertions.assertThat(fileResponse.getFullPath()).isEqualTo(fileEntity.getFullPath());
-		Assertions.assertThat(fileResponse.getUuid()).isEqualTo(fileEntity.getUuid());
+		assertThat(fileResponse.getFileName()).isEqualTo(file.getFileName());
+		assertThat(fileResponse.getSize()).isEqualTo(file.getSize());
+		assertThat(fileResponse.getFullPath()).isEqualTo(file.getFullPath());
+		assertThat(fileResponse.getUuid()).isEqualTo(file.getUuid());
 	}
 
 	@DisplayName("deleteFile : 정상 흐름")
 	@Test
 	@Transactional
-	public void deleteFile() throws IOException {
-
+	public void deleteFileTest() throws IOException {
 		// given
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo("testOwner");
+
 		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
 		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
-		MockMultipartFile mockFile = new MockMultipartFile("file1.txt", "file1.txt", "text/plain", new byte[] {123});
 
-		UUID uuid = UUID.randomUUID();
-		MyFile file = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello, uuid);
-		fileIoUtils.save(mockFile, file);
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		storageInfoRepositoryUtils.addFolder(storageInfo, 2L);
+		storageInfoRepositoryUtils.addFile(storageInfo, myFile);
 
 		// when
-		fileService.deleteFile("testOwner", file.getUuid());
+		fileService.deleteFile("testOwner", myFile.getUuid());
 
 		// then
-		MyFile deletedFile = fileRepository.findByUuid(uuid).get();
-		Assertions.assertThat(deletedFile.getStatus()).isEqualTo(FileItemStatus.DELETED);
+		MyFile deletedFile = fileRepository.findByUuid(myFile.getUuid()).get();
+		assertThat(storageInfo.getSize()).isEqualTo(0);
+		assertThat(deletedFile.getStatus()).isEqualTo(FileItemStatus.DELETED);
+		assertThat(storageInfo.getSize()).isEqualTo(0L);
+		assertThat(storageInfo.getFileCount()).isEqualTo(0L);
 	}
 
 	@DisplayName("moveFile : 정상 흐름")
 	@Test
 	@Transactional
-	public void moveFile() {
+	public void moveFileTest() {
 		// given
 		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
 		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
 		MyFolder world = folderRepositoryUtils.createAndPersistFolder("testOwner", "world", root);
 
 		MockMultipartFile mockFile1 = new MockMultipartFile("file1.txt", "file1.txt", "text/plain", new byte[] {123});
-		MockMultipartFile mockFile2 = new MockMultipartFile("file2.txt", "file2.txt", "text/plain", new byte[] {123});
 		MyFile file1 = fileRepositoryUtils.createAndPersistFile(mockFile1, "testOwner", hello);
-		MyFile file2 = fileRepositoryUtils.createAndPersistFile(mockFile2, "testOwner", world);
 		fileIoUtils.save(mockFile1, file1);
-		fileIoUtils.save(mockFile2, file2);
 
 		// when
 		FileResponse fileResponse = fileService.moveFile("testOwner", file1.getUuid(), world.getUuid());
 
 		// then
-		Assertions.assertThat(fileResponse.getFullPath()).isEqualTo("/world/file1.txt");
-
-		MyFile movedFile = fileRepository.findByUuid(file1.getUuid()).get();
-		Assertions.assertThat(movedFile.getFullPath()).isEqualTo("/world/file1.txt");
+		assertThat(fileResponse.getFullPath()).isEqualTo("/world/file1.txt");
+		assertThat(file1.getFullPath()).isEqualTo("/world/file1.txt");
 	}
 
 	@DisplayName("moveFile : 옮기려는 폴더에 동일한 이름의 파일이 존재하면 이동이 불가능하다.")
 	@Test
 	@Transactional
-	public void moveFileToSameFileNameExist() {
+	public void moveFileTestSameFileNameExist() {
 		// given
 		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
 		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
@@ -222,9 +199,8 @@ public class FileServiceTest {
 		// when - then
 		FileAlreadyExistException exception = assertThrows(FileAlreadyExistException.class,
 			() -> fileService.moveFile("testOwner", file1.getUuid(), world.getUuid()));
-		Assertions.assertThat(exception.getMessage()).isEqualTo("옮기려는 폴더에 동일한 이름의 파일이 존재해 이동이 불가능 합니다.");
+		assertThat(exception.getMessage()).isEqualTo("옮기려는 폴더에 동일한 이름의 파일이 존재해 이동이 불가능 합니다.");
 	}
-
 
 	private void deleteDirectoryAndFiles(File targetFolder) {
 		File[] files = targetFolder.listFiles();

--- a/src/test/java/com/jongmin/mystorage/service/FolderServiceTest.java
+++ b/src/test/java/com/jongmin/mystorage/service/FolderServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,14 +17,18 @@ import org.springframework.transaction.annotation.Transactional;
 import com.jongmin.mystorage.exception.FileAlreadyExistException;
 import com.jongmin.mystorage.model.MyFile;
 import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.StorageInfo;
 import com.jongmin.mystorage.model.enums.FileItemStatus;
 import com.jongmin.mystorage.repository.FileRepository;
 import com.jongmin.mystorage.repository.FolderRepository;
+import com.jongmin.mystorage.repository.StorageInfoRepository;
 import com.jongmin.mystorage.service.folder.FolderService;
+import com.jongmin.mystorage.service.response.FolderInfoResponse;
 import com.jongmin.mystorage.service.response.FolderResponse;
 import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
 import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
 
 import jakarta.persistence.EntityManager;
 
@@ -47,86 +49,72 @@ public class FolderServiceTest {
 	private FileIoUtils fileIoUtils;
 	@Autowired
 	private EntityManager entityManager;
+	@Autowired
+	private StorageInfoRepository storageInfoRepository;
+	@Autowired
+	private StorageInfoRepositoryUtils storageInfoRepositoryUtils;
 
-	@DisplayName("폴더가 없는 상태에서 폴더 생성 요청시 요청한 폴더와 root폴더가 같이 생성한다.")
-	@Test
-	@Transactional
-	void createFolderTestFirst() {
-		// given
-		String ownerName = "testOwner";
-		String folderName = "testFolder";
-		UUID parentFolderUuid = null;
-
-		// when
-		FolderResponse createdFolder = folderService.createFolder(ownerName, folderName, null);
-		List<MyFolder> myFolders = folderRepository.findAll();
-		System.out.println("myFolders.size() = " + myFolders.size());
-		// then
-		assertThat(createdFolder.getUuid()).isNotNull();
-		assertThat(createdFolder.getFolderName()).isEqualTo(folderName);
-		// 처음 폴더를 생성할 때는 root 폴더를 같이 생성한다.
-		assertThat(myFolders.size()).isEqualTo(2);
-	}
-
-	@DisplayName("폴더 생성 시 parentFolderUuid의 값이 유효하다면 해당 폴더 밑에 폴더가 생성된다.")
+	@DisplayName("createFolder : 아무 폴더도 없는 상태에서 폴더 생성 요청시 요청한 폴더와 root폴더가 같이 생성한다.")
 	@Test
 	@Transactional
 	void createFolderTest() {
-		// given
-		String ownerName = "testOwner";
-		String folderName1 = "testFolder1";
-		String folderName2 = "testFolder2";
-		FolderResponse createdFolderResponse1 = folderService
-			.createFolder(ownerName, folderName1, null);
-
 		// when
-		FolderResponse createdFolderResponse2 = folderService
-			.createFolder(ownerName, folderName2, createdFolderResponse1.getUuid());
+		FolderResponse createdFolder = folderService.createFolder("testOwner", "testFolder", null);
 
 		// then
-		Optional<MyFolder> createdFolder2 = folderRepository.findByUuid(createdFolderResponse2.getUuid());
-
-		assertThat(createdFolder2).isNotNull();
-		assertThat(createdFolder2.get().getParentFolder().getUuid()).isEqualTo(createdFolderResponse1.getUuid());
+		List<MyFolder> folders = folderRepository.findAll();
+		assertThat(folders.size()).isEqualTo(2);
+		assertThat(createdFolder.getFolderName()).isEqualTo("testFolder");
 	}
 
-	@DisplayName("폴더 생성시 부모 폴더가 내 폴더가 아니면 오류가 발생한다.")
+	@DisplayName("createFolder : 폴더 생성 시 parentFolderUuid의 값이 유효하다면 해당 폴더 하위에 폴더가 생성된다.")
+	@Test
+	@Transactional
+	void createFolderTest2() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+
+		// when
+		FolderResponse createdFolder = folderService.createFolder("testOwner", "testFolder", root.getUuid());
+
+		// then
+		MyFolder folder = folderRepository.findByUuid(createdFolder.getUuid()).get();
+		assertThat(createdFolder.getFullPath()).isEqualTo("/testFolder");
+		assertThat(folder.getParentFolder().getUuid()).isEqualTo(root.getUuid());
+	}
+
+	@DisplayName("createFolder : 다른 사람의 폴더의 자신의 하위 폴더를 생성하려고 하면 오류가 발생한다.")
 	@Test
 	@Transactional
 	void createFolderTestOtherOwner() {
 		// given
-		String ownerName1 = "testOwner1";
-		String ownerName2 = "testOwner2";
-		String folderName1 = "testFolder1";
-		String folderName2 = "testFolder2";
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
 
 		// when - then
-		FolderResponse createdFolderResponse1 = folderService.createFolder(ownerName1, folderName1, null);
 		assertThrows(
 			RuntimeException.class, () -> folderService
-				.createFolder(ownerName2, folderName2, createdFolderResponse1.getUuid())
+				.createFolder("testOwner1", "testFolder", root.getUuid())
 		);
 	}
 
-	@DisplayName("폴더 생성 시 해당 부모 폴더 밑에 동일한 이름의 폴더가 존재하면 폴더 생성에 실패한다.")
+	@DisplayName("createFolder : 동일한 이름의 폴더가 존재하면 폴더 생성에 실패한다.")
 	@Test
 	@Transactional
 	void createFolderWithDuplicateName() {
 		// given
-		String ownerName1 = "testOwner1";
-		String folderName1 = "testFolder1";
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
 
-		// when
-		FolderResponse createdFolderResponse1 = folderService.createFolder(ownerName1, folderName1, null);
+		entityManager.flush();
 		entityManager.clear();
 
 		// then
 		assertThrows(
-			RuntimeException.class, () -> folderService.createFolder(ownerName1, folderName1, null)
+			RuntimeException.class, () -> folderService.createFolder("testOwner", "hello", null)
 		);
 	}
 
-	@DisplayName("폴더 이동 테스트 : 정상적인 흐름 1")
+	@DisplayName("moveFolder : 정상적인 흐름")
 	@Test
 	@Transactional
 	void moveFolderTest() {
@@ -151,8 +139,7 @@ public class FolderServiceTest {
 		assertThat(file1.getFullPath()).isEqualTo("/hello/world2/world1/test.txt");
 	}
 
-
-	@DisplayName("폴더 이동 테스트 : 정상적인 흐름 2")
+	@DisplayName("moveFolder : 정상적인 흐름 2")
 	@Test
 	@Transactional
 	void moveFolderTest2() {
@@ -177,8 +164,7 @@ public class FolderServiceTest {
 		assertThat(file2.getFullPath()).isEqualTo("/hello/world2/file2.txt");
 	}
 
-
-	@DisplayName("폴더 이동 테스트 : 자신의 하위 폴더로 옮겨질 수 없습니다.")
+	@DisplayName("moveFolder : 자신의 하위 폴더로 옮겨질 수 없습니다.")
 	@Test
 	@Transactional
 	void moveFolderToChild() {
@@ -193,7 +179,7 @@ public class FolderServiceTest {
 		assertThat(exception.getMessage()).isEqualTo("자신의 하위 폴더로 옮겨질 수 없습니다.");
 	}
 
-	@DisplayName("폴더 이동 테스트 : 옮기려는 폴더 내에 이름이 동일한 폴더가 존재하면 폴더를 옮길 수 없습니다.")
+	@DisplayName("moveFolder : 옮기려는 폴더 내에 이름이 동일한 폴더가 존재s하면 폴더를 옮길 수 없습니다.")
 	@Test
 	@Transactional
 	void moveFolderToSameNameFolderExist() {
@@ -214,9 +200,12 @@ public class FolderServiceTest {
 	@Transactional
 	void deleteFolderTest() {
 		// given
+		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo("testOwner");
+
 		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
 		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
 		MyFolder world = folderRepositoryUtils.createAndPersistFolder("testOwner", "world", hello);
+		storageInfoRepositoryUtils.addFolder(storageInfo, 3L);
 
 		MockMultipartFile mockFile1 = new MockMultipartFile("file1.txt", "file1.txt", "text/plain", new byte[] {123});
 		MockMultipartFile mockFile2 = new MockMultipartFile("file2.txt", "file2.txt", "text/plain", new byte[] {123});
@@ -232,14 +221,14 @@ public class FolderServiceTest {
 		List<MyFolder> folders = folderRepository.findByOwnerNameAndFullPathStartingWith("testOwner", "/hello");
 		List<MyFile> files = fileRepository.findByOwnerNameAndFullPathStartingWith("testOwner", "/hello");
 
-		// then
 		assertThat(folders.size()).isEqualTo(2);
 		assertThat(files.size()).isEqualTo(2);
 		assertThat(folders).allMatch(folder -> folder.getStatus() == FileItemStatus.DELETED);
 		assertThat(files).allMatch(file -> file.getStatus() == FileItemStatus.DELETED);
+		assertThat(storageInfo.getFolderCount()).isEqualTo(2);
 	}
 
-	@DisplayName("readFolder: 최상단 폴더에서의 정상 흐름")
+	@DisplayName("readFolder : 최상단 폴더에서의 정상 흐름")
 	@Test
 	@Transactional
 	void readFolder() {


### PR DESCRIPTION

# Step 4

- [x] 파일과 폴더의 수정한 날짜 구현
- [x] 폴더 요약 구현
- [x] StorageInfo 테이블 도입 및 스토리지 요약 api 구현 
- [x] 테스트 구조 통일

## 1.   파일과 폴더의 수정한 날짜 구현

Spring Data 의 @LastModifiedDate을 이용하면 **필드 값 변경 시에 알아서 updateAt 필드를 갱신**해준다. 
예를 들어 파일이나 폴더가 이동했을 때 객체의 fullPath 값이 변경되는데, 그 때 내가 직접 수정한 날짜를 고쳐줄 필요가 없다.

**폴더가 변한 것은 없는데, 폴더 내부에 어떤 변화가 있을 때**가 문제가 된다.
**직접  updateAt 필드를 갱신**하는 로직을 추가한 부분을 아래 작성했다.
```
1. 파일의 생성 -> 생성된 파일의 폴더
2. 파일의 삭제 -> 삭제된 파일의 부모 폴더
3. 파일의 이동 -> 옮겨진 파일의 이전 부모 폴더, 현재 부모 폴더
4. 폴더의 생성 -> 생성된 폴더의 부모 폴더
5. 폴더의 삭제 -> 삭제된 폴더의 부모 폴더
6. 폴더의 이동 -> 이동한 폴더, 폴더의 이전 폴더, 현재 부모 폴더
```

<br>

---

## 2. 폴더/전체 요약 구현

이전에 폴더의 정보를 출력하는 ```readFolder()``` 함수를 구현했었다.
이 함수는 **폴더의 기본적인 정보와 함께 자식 폴더 리스트, 자식 파일 리스트를 1depth로 제공**한다.

**readFolder() 함수를 자신 하위의 모든 폴더 수, 모든 파일 수를 포함하여 return** 하도록 수정해보았다. 
자신 하위에 파일과 폴더가 대량으로 존재한다면 무거운 작업이 될 수 있다. 
일단은 이렇게 구현해두었지만 성능 상 문제가 발생한다면 분리된 요청으로 제공하는 게 바람직할 수도 있겠다.


이전에 언급된 적 있다시피 하위의 모든 파일과 폴더는 fullPath Like를 이용하면 쉽게 구할 수 있다.

``` SQL
SELECT Count(m), SUM(m.size)
FROM MY_FILE m
WHERE m.ownerName = "owerName" AND m.fullPath Like "fullpath%" AND m.satus=SAVED
```

<br>

---

## 3. StorageInfo  테이블 도입

위의 **readFolder() 함수를 최상단 폴더(root)에서 실행하면 존재하는 모든 폴더와 파일에 대한 수와 용량을 얻을 수 있다.** **하지만 모든 파일과 폴더를 읽는 작업이니 만큼 서버에 부하를 줄 수 있다.**

또한 **스토리지 안에 전체 파일과 폴더가 몇 개씩 존재하는지 그리고 용량을 얼만큼 사용하고 있는 지는 지속적으로 요청할 수 있는 정보**여야 한다.

**StorageInfo 테이블 도입하여 전체 파일 수, 전체 폴더 수, 사용 중인 용량이 지속적으로 업데이트**되도록 하였으며, **StorageInfo 테이블에만 접근하여 부담 없고 빠르게 스토리지에 대한 정보를 얻을 수 있다.**


```
참고) 모든 폴더가 자신의 하위에 파일이 몇 개가 있고 폴더가 몇 개가 있으며
용량은 얼마나 된다는 정보를 모두 가지고 있는 것은 효율적이지 못하다.

한 번의 생성이나 삭제 작업이 여러 칼럼에 걸친 복잡한 작업이 될 여지가 있으며,
효율적인 쿼리가 작성되지 않는다면 DB와 통신도 여러 번 발생하게 된다.
```

<br>

---

