### PR TITLE
Step5

### DIFF
--- a/src/main/java/com/jongmin/mystorage/controller/api/FileApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/FileApiController.java
@@ -17,8 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.jongmin.mystorage.controller.api.dto.MoveRequestDto;
 import com.jongmin.mystorage.controller.api.dto.UploadFileRequestDto;
+import com.jongmin.mystorage.service.SharedFileService;
 import com.jongmin.mystorage.service.file.FileService;
 import com.jongmin.mystorage.service.response.FileResponse;
+import com.jongmin.mystorage.service.response.SharedFileResponse;
 import com.jongmin.mystorage.service.response.StringResponse;
 
 import lombok.AllArgsConstructor;
@@ -28,6 +30,7 @@ import lombok.AllArgsConstructor;
 public class FileApiController {
 
 	private final FileService fileService;
+	private final SharedFileService sharedFileService;
 
 	@PostMapping("/api/files/upload")
 	public FileResponse uploadFile(@RequestHeader("ownerName") String ownerName,
@@ -66,5 +69,10 @@ public class FileApiController {
 								@PathVariable(name = "fileUuid", required = true) UUID fileUuid,
 								@RequestBody MoveRequestDto requestDto) {
 		return fileService.moveFile(ownerName, fileUuid, requestDto.getDestFolderUuid());
+	}
+
+	@PostMapping("/api/files/{fileUuid}/share")
+	public SharedFileResponse shareFile(@RequestHeader("ownerName") String ownerName, @PathVariable(name = "fileUuid", required = true) UUID fileUuid) {
+		return sharedFileService.createSharedFile(ownerName, fileUuid);
 	}
 }

--- a/src/main/java/com/jongmin/mystorage/controller/api/FileApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/FileApiController.java
@@ -34,7 +34,7 @@ public class FileApiController {
 
 	@PostMapping("/api/files/upload")
 	public FileResponse uploadFile(@RequestHeader("ownerName") String ownerName,
-									@ModelAttribute UploadFileRequestDto requestDto) {
+		@ModelAttribute UploadFileRequestDto requestDto) {
 		return fileService.uploadFile(ownerName, requestDto);
 	}
 
@@ -66,13 +66,14 @@ public class FileApiController {
 
 	@PostMapping("/api/files/{fileUuid}/move")
 	public FileResponse moveFile(@RequestHeader("ownerName") String ownerName,
-								@PathVariable(name = "fileUuid", required = true) UUID fileUuid,
-								@RequestBody MoveRequestDto requestDto) {
+		@PathVariable(name = "fileUuid", required = true) UUID fileUuid,
+		@RequestBody MoveRequestDto requestDto) {
 		return fileService.moveFile(ownerName, fileUuid, requestDto.getDestFolderUuid());
 	}
 
 	@PostMapping("/api/files/{fileUuid}/share")
-	public SharedFileResponse shareFile(@RequestHeader("ownerName") String ownerName, @PathVariable(name = "fileUuid", required = true) UUID fileUuid) {
+	public SharedFileResponse shareFile(@RequestHeader("ownerName") String ownerName,
+		@PathVariable(name = "fileUuid", required = true) UUID fileUuid) {
 		return sharedFileService.createSharedFile(ownerName, fileUuid);
 	}
 }

--- a/src/main/java/com/jongmin/mystorage/controller/api/FolderApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/FolderApiController.java
@@ -15,10 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.jongmin.mystorage.controller.api.dto.FolderUpdateDto;
 import com.jongmin.mystorage.controller.api.dto.MoveRequestDto;
+import com.jongmin.mystorage.service.SharedFolderService;
 import com.jongmin.mystorage.service.folder.FolderService;
-import com.jongmin.mystorage.service.response.FileResponse;
 import com.jongmin.mystorage.service.response.FolderInfoResponse;
 import com.jongmin.mystorage.service.response.FolderResponse;
+import com.jongmin.mystorage.service.response.SharedFolderResponse;
 import com.jongmin.mystorage.service.response.StringResponse;
 
 import lombok.AllArgsConstructor;
@@ -28,17 +29,18 @@ import lombok.AllArgsConstructor;
 public class FolderApiController {
 
 	private final FolderService folderService;
+	private final SharedFolderService sharedFolderService;
 
 	@PostMapping({"/api/folders", "/api/folders/{parentFolderId}"})
 	public FolderResponse createFolder(@RequestBody HashMap<String, String> map,
-										@PathVariable(name = "parentFolderId", required = false) UUID parentFolderId,
-										@RequestHeader("ownerName") String ownerName) {
+		@PathVariable(name = "parentFolderId", required = false) UUID parentFolderId,
+		@RequestHeader("ownerName") String ownerName) {
 		return folderService.createFolder(ownerName, map.get("folderName"), parentFolderId);
 	}
 
 	@GetMapping({"/api/folders", "/api/folders/{folderId}"})
 	public FolderInfoResponse readFolder(@PathVariable(name = "folderId", required = false) UUID folderId,
-											@RequestHeader("ownerName") String ownerName) {
+		@RequestHeader("ownerName") String ownerName) {
 		return folderService.readFolder(ownerName, folderId);
 	}
 
@@ -51,7 +53,7 @@ public class FolderApiController {
 
 	@DeleteMapping("/api/folders/{folderId}")
 	public StringResponse deleteFolder(@PathVariable(name = "folderId", required = false) UUID folderId,
-											@RequestHeader("ownerName") String ownerName) {
+		@RequestHeader("ownerName") String ownerName) {
 		return folderService.deleteFolder(ownerName, folderId);
 	}
 
@@ -60,5 +62,11 @@ public class FolderApiController {
 		@PathVariable(name = "folderUuid", required = true) UUID transferFolderUuid,
 		@RequestBody MoveRequestDto requestDto) {
 		return folderService.moveFolder(ownerName, transferFolderUuid, requestDto.getDestFolderUuid());
+	}
+
+	@PostMapping("/api/folders/{folderUuid}/share")
+	public SharedFolderResponse shareFile(@RequestHeader("ownerName") String ownerName,
+		@PathVariable(name = "folderUuid", required = true) UUID folderUuid) {
+		return sharedFolderService.createSharedFolder(ownerName, folderUuid);
 	}
 }

--- a/src/main/java/com/jongmin/mystorage/controller/api/SharedFileApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/SharedFileApiController.java
@@ -1,0 +1,46 @@
+package com.jongmin.mystorage.controller.api;
+
+import java.util.UUID;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jongmin.mystorage.service.SharedFileService;
+import com.jongmin.mystorage.service.response.SharedFileResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class SharedFileApiController {
+
+	private final SharedFileService sharedFileService;
+
+	@GetMapping("/api/share/files/{shareFileUuid}")
+	public SharedFileResponse readSharedFile(
+		@PathVariable(name = "shareFileUuid", required = true) UUID sharedFileUuid) {
+		return sharedFileService.readSharedFile(sharedFileUuid);
+	}
+
+	@GetMapping("/api/share/files/{shareFileUuid}/download")
+	public ResponseEntity<Resource> downloadSharedFile(
+		@PathVariable(name = "shareFileUuid", required = true) UUID sharedFileUuid) {
+
+		Resource fileResource = sharedFileService.downloadSharedFile(sharedFileUuid);
+		String attachment = fileResource.getFilename().substring(37);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+
+		headers.setContentDispositionFormData("attachment", attachment);
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(fileResource);
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/controller/api/SharedFolderApiController.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/SharedFolderApiController.java
@@ -1,0 +1,77 @@
+package com.jongmin.mystorage.controller.api;
+
+import java.util.UUID;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jongmin.mystorage.controller.api.dto.UploadSharedFileRequestDto;
+import com.jongmin.mystorage.service.SharedFolderService;
+import com.jongmin.mystorage.service.response.SharedFolderInfoResponse;
+import com.jongmin.mystorage.service.response.SharedFolderItem;
+import com.jongmin.mystorage.service.response.StringResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+
+@RestController
+@AllArgsConstructor
+public class SharedFolderApiController {
+
+	private final SharedFolderService sharedFolderService;
+
+	@GetMapping({"/api/share/folders/{sharedFolderId}", "/api/share/folders/{sharedFolderId}/**"})
+	public SharedFolderInfoResponse readFolder(
+		@PathVariable(name = "sharedFolderId", required = true) UUID sharedFolderId,
+		HttpServletRequest request) {
+		if (request.getRequestURI().length() == 54) {
+			return sharedFolderService.readFolder(sharedFolderId, null);
+		} else {
+			String relativePath = request.getRequestURI().substring(55);
+			return sharedFolderService.readFolder(sharedFolderId, relativePath);
+		}
+	}
+
+	@GetMapping("/api/share/folders/download/{sharedFolderId}/**")
+	public ResponseEntity<Resource> downloadFileInSharedFolder(
+		@PathVariable(name = "sharedFolderId", required = true) UUID sharedFolderId,
+		HttpServletRequest request) {
+		Resource fileResource = null;
+		if (request.getRequestURI().length() <= 63) {
+			throw new RuntimeException("공유된 폴더에 자체에 대해선 다운로드 요청을 보낼 수 없습니다. 파일을 다운로드 요청해주세요.");
+		} else {
+			String relativePath = request.getRequestURI().substring(64);
+			System.out.println("relativePath = " + relativePath);
+			fileResource = sharedFolderService.downloadFile(sharedFolderId, relativePath);
+		}
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+
+		String attachment = fileResource.getFilename().substring(37);
+		headers.setContentDispositionFormData("attachment", attachment);
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(fileResource);
+	}
+
+	@PostMapping("/api/share/folders/upload")
+	public SharedFolderItem uploadFileInSharedFolder(UploadSharedFileRequestDto requestDto) {
+		return sharedFolderService.uploadFile(requestDto);
+	}
+
+	@DeleteMapping("/api/share/folders/{sharedFolderId}/**")
+	public StringResponse deleteFileInSharedFolder(
+		@PathVariable(name = "sharedFolderId", required = true) UUID sharedFolderId,
+		HttpServletRequest request) {
+		String relativePath = request.getRequestURI().substring(55);
+		return sharedFolderService.deleteFile(sharedFolderId, relativePath);
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/controller/api/dto/UploadSharedFileRequestDto.java
+++ b/src/main/java/com/jongmin/mystorage/controller/api/dto/UploadSharedFileRequestDto.java
@@ -1,0 +1,22 @@
+package com.jongmin.mystorage.controller.api.dto;
+
+import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadSharedFileRequestDto {
+	@NotNull(message = "파일을 올려주세요.")
+	private MultipartFile multipartFile;
+	private UUID folderUuid;
+	private String relativePath;
+}

--- a/src/main/java/com/jongmin/mystorage/model/MyFile.java
+++ b/src/main/java/com/jongmin/mystorage/model/MyFile.java
@@ -81,9 +81,7 @@ public class MyFile extends FileSystemItem {
 
 	public MyFile reset() {
 		this.parentPath = parentFolder.getFullPath();
-		System.out.println("this.parentPath = " + this.parentPath);
 		this.fullPath = parentPath + "/" + fileName;
-		System.out.println("this.fullPath = " + this.fullPath);
 		return this;
 	}
 }

--- a/src/main/java/com/jongmin/mystorage/model/SharedFile.java
+++ b/src/main/java/com/jongmin/mystorage/model/SharedFile.java
@@ -1,0 +1,36 @@
+package com.jongmin.mystorage.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class SharedFile extends BaseEntity {
+	private Long id;
+	private UUID uuid;
+	private String ownerName;
+	private String fullPath;
+	private String fileName;
+	private LocalDateTime expiredAt;
+	@ManyToOne
+	private MyFile myFile;
+
+	@Builder
+	public SharedFile(Long id, UUID uuid, String ownerName, String fullPath, String fileName, LocalDateTime expiredAt,
+		MyFile myFile) {
+		this.id = id;
+		this.uuid = uuid;
+		this.ownerName = ownerName;
+		this.fullPath = fullPath;
+		this.fileName = fileName;
+		this.expiredAt = expiredAt;
+		this.myFile = myFile;
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/model/SharedFolder.java
+++ b/src/main/java/com/jongmin/mystorage/model/SharedFolder.java
@@ -1,0 +1,35 @@
+package com.jongmin.mystorage.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class SharedFolder extends BaseEntity {
+	private Long id;
+	private UUID sharedId;
+	private String ownerName;
+	private String fullPath;
+	private String folderName;
+	private LocalDateTime expiredAt;
+	@ManyToOne
+	private MyFolder myFolder;
+
+	@Builder
+	public SharedFolder(Long id, UUID sharedId, String ownerName, String fullPath, LocalDateTime expiredAt,
+		MyFolder myFolder) {
+		this.id = id;
+		this.sharedId = sharedId;
+		this.ownerName = ownerName;
+		this.fullPath = fullPath;
+		this.expiredAt = expiredAt;
+		this.myFolder = myFolder;
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/repository/FileRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/FileRepository.java
@@ -21,7 +21,7 @@ public interface FileRepository extends JpaRepository<MyFile, Long> {
 
 	Optional<MyFile> findByUuidAndStatus(UUID fileUuid, FileItemStatus status);
 
-	Optional<MyFile> findByFileName(String fileName);
+	Optional<MyFile> findByOwnerNameAndFullPathAndStatus(String ownerName, String fullPath, FileItemStatus status);
 
 	List<MyFile> findByOwnerNameAndFullPathStartingWith(String ownerName, String fullPath);
 

--- a/src/main/java/com/jongmin/mystorage/repository/SharedFileRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/SharedFileRepository.java
@@ -1,0 +1,14 @@
+package com.jongmin.mystorage.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.jongmin.mystorage.model.SharedFile;
+
+@Repository
+public interface SharedFileRepository extends JpaRepository<SharedFile, Long> {
+	Optional<SharedFile> findByUuid(UUID uuid);
+}

--- a/src/main/java/com/jongmin/mystorage/repository/SharedFolderRepository.java
+++ b/src/main/java/com/jongmin/mystorage/repository/SharedFolderRepository.java
@@ -1,0 +1,14 @@
+package com.jongmin.mystorage.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.jongmin.mystorage.model.SharedFolder;
+
+@Repository
+public interface SharedFolderRepository extends JpaRepository<SharedFolder, Long> {
+	Optional<SharedFolder> findBySharedId(UUID uuid);
+}

--- a/src/main/java/com/jongmin/mystorage/service/SharedFileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/SharedFileService.java
@@ -1,0 +1,48 @@
+package com.jongmin.mystorage.service;
+
+import java.util.UUID;
+
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import com.jongmin.mystorage.exception.FileNotInFileSystemException;
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.SharedFile;
+import com.jongmin.mystorage.repository.FileRepository;
+import com.jongmin.mystorage.repository.SharedFileRepository;
+import com.jongmin.mystorage.service.response.SharedFileResponse;
+import com.jongmin.mystorage.utils.SharedFileUtils;
+import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SharedFileService {
+
+	private final FileRepositoryUtils fileRepositoryUtils;
+	private final SharedFileUtils sharedFileUtils;
+	private final FileIoUtils fileIoUtils;
+
+	public SharedFileResponse createSharedFile(String ownerName, UUID fileUuid) {
+		MyFile file = fileRepositoryUtils.getFileByUuidWithSavedStatus(ownerName, fileUuid);
+		SharedFile sharedFile = sharedFileUtils.createAndPersistSharedFile(file);
+		return SharedFileResponse.fromSharedFile(sharedFile);
+	}
+
+
+	public SharedFileResponse readSharedFile(UUID sharedFileUuid) {
+		SharedFile sharedFile = sharedFileUtils.getSharedFile(sharedFileUuid);
+		return SharedFileResponse.fromSharedFile(sharedFile);
+	}
+
+	public Resource downloadSharedFile(UUID sharedFileUuid) {
+		SharedFile sharedFile = sharedFileUtils.getSharedFile(sharedFileUuid);
+		if (fileIoUtils.fileNotExists(sharedFile.getMyFile())) {
+			throw new FileNotInFileSystemException("파일이 디스크 상에 존재하지 않습니다.");
+		}
+		return fileIoUtils.fileToResource(sharedFile.getMyFile());
+	}
+}
+

--- a/src/main/java/com/jongmin/mystorage/service/SharedFolderService.java
+++ b/src/main/java/com/jongmin/mystorage/service/SharedFolderService.java
@@ -1,0 +1,157 @@
+package com.jongmin.mystorage.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jongmin.mystorage.controller.api.dto.UploadFileRequestDto;
+import com.jongmin.mystorage.controller.api.dto.UploadSharedFileRequestDto;
+import com.jongmin.mystorage.exception.FileNotInFileSystemException;
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFolder;
+import com.jongmin.mystorage.model.enums.FileItemStatus;
+import com.jongmin.mystorage.repository.FileRepository;
+import com.jongmin.mystorage.repository.FolderRepository;
+import com.jongmin.mystorage.repository.SharedFolderRepository;
+import com.jongmin.mystorage.service.file.FileService;
+import com.jongmin.mystorage.service.response.FileResponse;
+import com.jongmin.mystorage.service.response.SharedFolderInfoResponse;
+import com.jongmin.mystorage.service.response.SharedFolderItem;
+import com.jongmin.mystorage.service.response.SharedFolderResponse;
+import com.jongmin.mystorage.service.response.StringResponse;
+import com.jongmin.mystorage.utils.SharedFolderUtils;
+import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SharedFolderService {
+
+	private final FolderRepositoryUtils folderRepositoryUtils;
+	private final SharedFolderUtils sharedFolderUtils;
+	private final SharedFolderRepository sharedFolderRepository;
+	private final FolderRepository folderRepository;
+	private final FileRepository fileRepository;
+
+	private final FileIoUtils fileIoUtils;
+
+	private final FileService fileService;
+
+	public SharedFolderResponse createSharedFolder(String ownerName, UUID folderUuid) {
+		MyFolder folder = folderRepositoryUtils.getFolderByUuidWithSavedStatus(ownerName,
+			folderUuid);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(folder);
+		return SharedFolderResponse.fromSharedFolder(sharedFolder);
+
+	}
+
+	public SharedFolderInfoResponse readFolder(UUID sharedFolderId, String relativePath) {
+		if (relativePath == null) {
+			relativePath = "";
+		}
+
+		Optional<SharedFolder> bySharedId = sharedFolderRepository.findBySharedId(sharedFolderId);
+		if (bySharedId.isEmpty()) {
+			throw new RuntimeException("잘못된 공유 폴더에 대한 접근입니다.");
+		}
+		SharedFolder sharedFolder = bySharedId.get();
+		String fullPath = sharedFolder.getMyFolder().getFullPath() + relativePath;
+		String ownerName = sharedFolder.getOwnerName();
+
+		Optional<MyFolder> byFullPath = folderRepository.findByOwnerNameAndFullPath(ownerName, fullPath);
+		if (byFullPath.isEmpty()) {
+			throw new RuntimeException("잘못된 하위 폴더 대한 접근입니다.");
+		}
+		MyFolder folder = byFullPath.get();
+
+		return SharedFolderInfoResponse.createSharedFolderInfoResponse(sharedFolder, folder, relativePath);
+	}
+
+	public Resource downloadFile(UUID sharedFolderId, String relativePath) {
+		if (relativePath == null) {
+			relativePath = "";
+		}
+
+		Optional<SharedFolder> bySharedId = sharedFolderRepository.findBySharedId(sharedFolderId);
+		if (bySharedId.isEmpty()) {
+			throw new RuntimeException("잘못된 공유 폴더에 대한 접근입니다.");
+		}
+		SharedFolder sharedFolder = bySharedId.get();
+		String fullPath = sharedFolder.getMyFolder().getFullPath() + relativePath;
+		String ownerName = sharedFolder.getOwnerName();
+
+		Optional<MyFile> byFullPath = fileRepository.findByOwnerNameAndFullPathAndStatus(ownerName, fullPath,
+			FileItemStatus.SAVED);
+		if (byFullPath.isEmpty()) {
+			throw new RuntimeException("잘못된 하위 파일에 대한 접근입니다.");
+		}
+
+		MyFile file = byFullPath.get();
+		if (fileIoUtils.fileNotExists(file)) {
+			throw new FileNotInFileSystemException("파일이 디스크 상에 존재하지 않습니다.");
+		}
+		return fileIoUtils.fileToResource(file);
+	}
+
+	public SharedFolderItem uploadFile(UploadSharedFileRequestDto requestDto) {
+		UUID sharedFolderId = requestDto.getFolderUuid();
+		String relativePath = requestDto.getRelativePath();
+		if (relativePath == null) {
+			relativePath = "";
+		}
+
+		Optional<SharedFolder> bySharedId = sharedFolderRepository.findBySharedId(sharedFolderId);
+		if (bySharedId.isEmpty()) {
+			throw new RuntimeException("잘못된 공유 폴더에 대한 접근입니다.");
+		}
+		SharedFolder sharedFolder = bySharedId.get();
+		String fullPath = sharedFolder.getMyFolder().getFullPath() + relativePath;
+		String ownerName = sharedFolder.getOwnerName();
+
+		Optional<MyFolder> byFullPath = folderRepository.findByOwnerNameAndFullPath(ownerName, fullPath);
+		if (byFullPath.isEmpty()) {
+			throw new RuntimeException("잘못된 하위 폴더 대한 접근입니다.");
+		}
+		MyFolder folder = byFullPath.get();
+
+		// fileService의 uploadFile로 실행을 넘김
+		FileResponse fileResponse = fileService.uploadFile(ownerName,
+			new UploadFileRequestDto(requestDto.getMultipartFile(), folder.getUuid()));
+
+		String fileRelativePath = fileResponse.getFullPath().replace(sharedFolder.getFullPath(), "");
+
+		return new SharedFolderItem("File", fileRelativePath, fileResponse.getFileName(), fileResponse.getSize());
+	}
+
+	public StringResponse deleteFile(UUID sharedFolderId, String relativePath) {
+		if (relativePath == null) {
+			relativePath = "";
+		}
+
+		Optional<SharedFolder> bySharedId = sharedFolderRepository.findBySharedId(sharedFolderId);
+		if (bySharedId.isEmpty()) {
+			throw new RuntimeException("잘못된 공유 폴더에 대한 접근입니다.");
+		}
+		SharedFolder sharedFolder = bySharedId.get();
+		String fullPath = sharedFolder.getMyFolder().getFullPath() + relativePath;
+		String ownerName = sharedFolder.getOwnerName();
+		System.out.println("fullPath = " + fullPath);
+		System.out.println("ownerName = " + ownerName);
+		Optional<MyFile> byFullPath = fileRepository.findByOwnerNameAndFullPathAndStatus(ownerName, fullPath,
+			FileItemStatus.SAVED);
+		if (byFullPath.isEmpty()) {
+			throw new RuntimeException("잘못된 하위 파일에 대한 접근입니다.");
+		}
+		MyFile file = byFullPath.get();
+
+		return fileService.deleteFile(file.getOwnerName(), file.getUuid());
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/service/file/FileService.java
+++ b/src/main/java/com/jongmin/mystorage/service/file/FileService.java
@@ -43,7 +43,7 @@ public class FileService {
 		}
 
 		StorageInfo storageInfo = storageInfoRepositoryUtils.getStorageInfo(ownerName);
-		if (storageInfo.getSize() + requestDto.getMultipartFile().getSize() >  storageInfo.getMaxSize()) {
+		if (storageInfo.getSize() + requestDto.getMultipartFile().getSize() > storageInfo.getMaxSize()) {
 			throw new RuntimeException("자신의 스토리지 용량을 초과하여 저장할 수 없습니다.");
 		}
 

--- a/src/main/java/com/jongmin/mystorage/service/response/SharedFileResponse.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/SharedFileResponse.java
@@ -1,0 +1,36 @@
+package com.jongmin.mystorage.service.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.SharedFile;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SharedFileResponse {
+	private String fileName;
+	private UUID uuid;
+	private Long size;
+	private LocalDateTime expiredAt;
+
+	@Builder
+	public SharedFileResponse(String fileName, UUID uuid, Long size, LocalDateTime expiredAt) {
+		this.fileName = fileName;
+		this.uuid = uuid;
+		this.size = size;
+		this.expiredAt = expiredAt;
+	}
+
+	public static SharedFileResponse fromSharedFile(SharedFile sharedFile) {
+		MyFile file = sharedFile.getMyFile();
+		return SharedFileResponse.builder()
+			.fileName(file.getFileName())
+			.uuid(sharedFile.getUuid())
+			.size(file.getSize())
+			.expiredAt(sharedFile.getExpiredAt())
+			.build();
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/service/response/SharedFolderInfoResponse.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/SharedFolderInfoResponse.java
@@ -1,0 +1,63 @@
+package com.jongmin.mystorage.service.response;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFolder;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SharedFolderInfoResponse {
+
+	private UUID sharedId;
+	private LocalDateTime expiredAt;
+	private String relativePath;
+	private List<SharedFolderItem> folders;
+	private List<SharedFolderItem> files;
+
+	@Builder
+	public SharedFolderInfoResponse(UUID sharedId, LocalDateTime expiredAt, String relativePath,
+		List<SharedFolderItem> folders, List<SharedFolderItem> files) {
+		this.sharedId = sharedId;
+		this.expiredAt = expiredAt;
+		this.relativePath = relativePath;
+		this.folders = folders;
+		this.files = files;
+	}
+
+	public static SharedFolderInfoResponse createSharedFolderInfoResponse(SharedFolder sharedFolder, MyFolder myFolder,
+		String relativePath) {
+
+		List<SharedFolderItem> folderItems = new ArrayList<>();
+		if (myFolder.getChildFolders() != null) {
+			for (MyFolder folder :
+				myFolder.getChildFolders()) {
+				folderItems.add(
+					new SharedFolderItem("folder", folder.getFullPath().replace(sharedFolder.getFullPath(), ""),
+						folder.getFolderName(), 0L));
+			}
+		}
+
+		List<SharedFolderItem> fileItems = new ArrayList<>();
+		if (myFolder.getFiles() != null) {
+			for (MyFile file :
+				myFolder.getFiles()) {
+				fileItems.add(new SharedFolderItem("file", file.getFullPath().replace(sharedFolder.getFullPath(), ""),
+					file.getFileName(), file.getSize()));
+			}
+		}
+
+		return SharedFolderInfoResponse.builder().sharedId(sharedFolder.getSharedId())
+			.expiredAt(sharedFolder.getExpiredAt())
+			.relativePath(relativePath)
+			.folders(folderItems)
+			.files(fileItems)
+			.build();
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/service/response/SharedFolderItem.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/SharedFolderItem.java
@@ -1,0 +1,21 @@
+package com.jongmin.mystorage.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SharedFolderItem {
+
+	private String type;
+	private String relativePath;
+	private String name;
+	private Long size;
+
+	@Builder
+	public SharedFolderItem(String type, String relativePath, String name, Long size) {
+		this.type = type;
+		this.relativePath = relativePath;
+		this.name = name;
+		this.size = size;
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/service/response/SharedFolderResponse.java
+++ b/src/main/java/com/jongmin/mystorage/service/response/SharedFolderResponse.java
@@ -1,0 +1,32 @@
+package com.jongmin.mystorage.service.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFolder;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SharedFolderResponse {
+	private LocalDateTime expiredAt;
+	private UUID sharedId;
+	private String folderName;
+
+	@Builder
+	public SharedFolderResponse(String folderName, UUID sharedId, LocalDateTime expiredAt) {
+		this.folderName = folderName;
+		this.sharedId = sharedId;
+		this.expiredAt = expiredAt;
+	}
+
+	public static SharedFolderResponse fromSharedFolder(SharedFolder sharedFolder) {
+		return SharedFolderResponse.builder()
+			.sharedId(sharedFolder.getSharedId())
+			.expiredAt(sharedFolder.getExpiredAt())
+			.folderName(sharedFolder.getMyFolder().getFolderName())
+			.build();
+	}
+}

--- a/src/main/java/com/jongmin/mystorage/utils/SharedFileUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/SharedFileUtils.java
@@ -1,0 +1,42 @@
+package com.jongmin.mystorage.utils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.SharedFile;
+import com.jongmin.mystorage.repository.SharedFileRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class SharedFileUtils {
+
+	private final SharedFileRepository sharedFileRepository;
+
+	public SharedFile createAndPersistSharedFile(MyFile file) {
+		SharedFile sharedFile = SharedFile.builder()
+			.myFile(file)
+			.expiredAt(LocalDateTime.now().plusHours(3))
+			.uuid(UUID.randomUUID())
+			.ownerName(file.getOwnerName())
+			.fullPath(file.getFullPath())
+			.fileName(file.getFileName())
+			.build();
+		return sharedFileRepository.save(sharedFile);
+	}
+
+	public SharedFile getSharedFile(UUID sharedFileUuid) {
+		Optional<SharedFile> bySharedId = sharedFileRepository.findByUuid(sharedFileUuid);
+		SharedFile sharedFile = bySharedId.orElseThrow(() -> new RuntimeException("해당 uuid로 공유된 파일이 존재하지 않습니다."));
+		if (sharedFile.getExpiredAt().isBefore(LocalDateTime.now())) {
+			throw new RuntimeException("파일 공유가 종료되었습니다.");
+		}
+		return sharedFile;
+	}
+
+}

--- a/src/main/java/com/jongmin/mystorage/utils/SharedFolderUtils.java
+++ b/src/main/java/com/jongmin/mystorage/utils/SharedFolderUtils.java
@@ -1,0 +1,39 @@
+package com.jongmin.mystorage.utils;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Configuration;
+
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFolder;
+import com.jongmin.mystorage.repository.SharedFolderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class SharedFolderUtils {
+
+	private final SharedFolderRepository sharedFolderRepository;
+
+	public SharedFolder createAndPersistSharedFolder(MyFolder folder) {
+		SharedFolder sharedFolder = SharedFolder.builder()
+			.myFolder(folder)
+			.expiredAt(LocalDateTime.now().plusHours(3))
+			.sharedId(UUID.randomUUID())
+			.ownerName(folder.getOwnerName())
+			.fullPath(folder.getFullPath())
+			.build();
+		return sharedFolderRepository.save(sharedFolder);
+	}
+
+	// public SharedFolder getSharedFolder(UUID sharedFolderUuid) {
+	// 	Optional<SharedFolder> bySharedId = sharedFolderRepository.findBySharedId(sharedFolderUuid);
+	// 	SharedFolder sharedFolder = bySharedId.orElseThrow(() -> new RuntimeException("해당 uuid로 공유된 폴더가 존재하지 않습니다."));
+	// 	if (sharedFolder.getExpiredAt().isBefore(LocalDateTime.now())) {
+	// 		throw new RuntimeException("폴더 공유가 종료되었습니다.");
+	// 	}
+	// 	return sharedFolder;
+	// }
+}

--- a/src/test/java/com/jongmin/mystorage/service/SharedFileServiceTest.java
+++ b/src/test/java/com/jongmin/mystorage/service/SharedFileServiceTest.java
@@ -1,0 +1,127 @@
+package com.jongmin.mystorage.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFile;
+import com.jongmin.mystorage.repository.FileRepository;
+import com.jongmin.mystorage.repository.FolderRepository;
+import com.jongmin.mystorage.repository.SharedFileRepository;
+import com.jongmin.mystorage.repository.StorageInfoRepository;
+import com.jongmin.mystorage.service.file.FileService;
+import com.jongmin.mystorage.service.response.SharedFileResponse;
+import com.jongmin.mystorage.utils.SharedFileUtils;
+import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
+import com.jongmin.mystorage.utils.ioutils.FolderIolUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.StorageInfoRepositoryUtils;
+
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class SharedFileServiceTest {
+
+	@Value("${file.storage.baseDir}")
+	private String baseDir;
+	@Autowired
+	private FolderRepository folderRepository;
+	@Autowired
+	private FileRepository fileRepository;
+	@Autowired
+	private FileRepositoryUtils fileRepositoryUtils;
+	@Autowired
+	private FolderRepositoryUtils folderRepositoryUtils;
+	@Autowired
+	private FolderIolUtils folderIolUtils;
+	@Autowired
+	private FileIoUtils fileIoUtils;
+	@Autowired
+	private FileService fileService;
+	@Autowired
+	private StorageInfoRepository storageInfoRepository;
+	@Autowired
+	private StorageInfoRepositoryUtils storageInfoRepositoryUtils;
+	@Autowired
+	private SharedFileService sharedFileService;
+	@Autowired
+	private SharedFileRepository sharedFileRepository;
+	@Autowired
+	private SharedFileUtils sharedFileUtils;
+	@Autowired
+	private EntityManager entityManager;
+
+	@AfterEach
+	public void clearFolder() {
+		File file = new File(baseDir);
+		deleteDirectoryAndFiles(file);
+	}
+
+	@DisplayName("createSharedFile : 정상 흐름")
+	@Test
+	@Transactional
+	public void createSharedFile() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		// when
+		SharedFileResponse response = sharedFileService.createSharedFile("testOwner", myFile.getUuid());
+
+		// then
+		List<SharedFile> all = sharedFileRepository.findAll();
+		assertThat(all.size()).isEqualTo(1);
+		assertThat(all.get(0).getMyFile().getFullPath()).isEqualTo("/hello/file.txt");
+	}
+
+	@DisplayName("readSharedFile : 정상 흐름")
+	@Test
+	@Transactional
+	public void readSharedFile() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+		SharedFile sharedFile = sharedFileUtils.createAndPersistSharedFile(myFile);
+
+		// when
+		SharedFileResponse readResponse = sharedFileService.readSharedFile(sharedFile.getUuid());
+
+		// then
+		assertThat(readResponse.getFileName()).isEqualTo("file.txt");
+		assertThat(readResponse.getUuid()).isEqualTo(sharedFile.getUuid());
+		assertThat(readResponse.getSize()).isEqualTo(1);
+		assertThat(readResponse.getExpiredAt()).isEqualTo(sharedFile.getExpiredAt());
+	}
+
+	private void deleteDirectoryAndFiles(File targetFolder) {
+		File[] files = targetFolder.listFiles();
+		for (File file : files) {
+			if (file.isDirectory()) {
+				deleteDirectoryAndFiles(file);
+			}
+			file.delete();
+		}
+	}
+}

--- a/src/test/java/com/jongmin/mystorage/service/SharedFolderServiceTest.java
+++ b/src/test/java/com/jongmin/mystorage/service/SharedFolderServiceTest.java
@@ -1,0 +1,321 @@
+package com.jongmin.mystorage.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jongmin.mystorage.controller.api.dto.UploadSharedFileRequestDto;
+import com.jongmin.mystorage.model.MyFile;
+import com.jongmin.mystorage.model.MyFolder;
+import com.jongmin.mystorage.model.SharedFolder;
+import com.jongmin.mystorage.model.enums.FileItemStatus;
+import com.jongmin.mystorage.repository.FileRepository;
+import com.jongmin.mystorage.repository.FolderRepository;
+import com.jongmin.mystorage.repository.SharedFolderRepository;
+import com.jongmin.mystorage.service.response.SharedFolderInfoResponse;
+import com.jongmin.mystorage.service.response.SharedFolderItem;
+import com.jongmin.mystorage.service.response.SharedFolderResponse;
+import com.jongmin.mystorage.service.response.StringResponse;
+import com.jongmin.mystorage.utils.SharedFolderUtils;
+import com.jongmin.mystorage.utils.ioutils.FileIoUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FileRepositoryUtils;
+import com.jongmin.mystorage.utils.repositorytutils.FolderRepositoryUtils;
+
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class SharedFolderServiceTest {
+
+	@Autowired
+	private SharedFolderService sharedFolderService;
+	@Autowired
+	private SharedFolderRepository sharedFolderRepository;
+	@Autowired
+	private FolderRepository folderRepository;
+	@Autowired
+	private FileRepository fileRepository;
+	@Autowired
+	private FolderRepositoryUtils folderRepositoryUtils;
+	@Autowired
+	private SharedFolderUtils sharedFolderUtils;
+	@Autowired
+	private FileIoUtils fileIoUtils;
+	@Autowired
+	private FileRepositoryUtils fileRepositoryUtils;
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("createSharedFolder: 공유 폴더 생성 정상 흐름")
+	@Transactional
+	void createSharedFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+
+		// when
+		SharedFolderResponse response = sharedFolderService.createSharedFolder("testOwner", hello.getUuid());
+
+		// then
+		assertThat(response.getExpiredAt()).isAfter(LocalDateTime.now().plusHours(2))
+			.isBefore(LocalDateTime.now().plusHours(3));
+		assertThat(response.getFolderName()).isEqualTo("hello");
+	}
+
+	@Test
+	@DisplayName("readFolder: 공유 폴더 읽기 정상 흐름")
+	@Transactional
+	void readFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MyFolder world1 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world1", hello);
+		MyFolder world2 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world2", hello);
+		MyFolder world3 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world3", hello);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		entityManager.clear();
+
+		// when
+		SharedFolderInfoResponse response = sharedFolderService.readFolder(sharedFolder.getSharedId(), null);
+
+		// then
+		assertThat(response.getFolders().size()).isEqualTo(3);
+		assertThat(response.getFiles().size()).isEqualTo(1);
+		assertThat(response.getRelativePath()).isEqualTo("");
+	}
+
+	@Test
+	@DisplayName("readFolder: 공유 폴더의 하위 폴더 읽기 정상 흐름")
+	@Transactional
+	void readFolderInSharedFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MyFolder world1 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world1", hello);
+		MyFolder world2 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world2", world1);
+		MyFolder world3 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world3", world1);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", world1);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		entityManager.clear();
+
+		// when
+		SharedFolderInfoResponse response = sharedFolderService.readFolder(sharedFolder.getSharedId(), "/world1");
+
+		// then
+		assertThat(response.getFolders().size()).isEqualTo(2);
+		assertThat(response.getFiles().size()).isEqualTo(1);
+		assertThat(response.getRelativePath()).isEqualTo("/world1");
+	}
+
+	@Test
+	@DisplayName("readFolder: 공유 폴더에 없는 하위 폴더에 대한 접근 오류")
+	@Transactional
+	void readWrongFolderInSharedFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MyFolder world1 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world1", hello);
+		MyFolder world2 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world2", world1);
+		MyFolder world3 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world3", world1);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", world1);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		// when - then
+		RuntimeException exception = assertThrows(RuntimeException.class,
+			() -> sharedFolderService.readFolder(sharedFolder.getSharedId(), "/world2"));
+		assertThat(exception.getMessage()).isEqualTo("잘못된 하위 폴더 대한 접근입니다.");
+	}
+
+	@Test
+	@DisplayName("uploadFile: 공유 폴더 하위 폴더의 파일 업로드 정상 흐름")
+	@Transactional
+	void uploadFile() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		UploadSharedFileRequestDto requestDto = new UploadSharedFileRequestDto(mockFile, sharedFolder.getSharedId(),
+			null);
+
+		// when
+		SharedFolderItem response = sharedFolderService.uploadFile(requestDto);
+
+		// then
+		assertThat(response.getSize()).isEqualTo(1);
+		assertThat(response.getName()).isEqualTo("file.txt");
+		assertThat(response.getType()).isEqualTo("File");
+		assertThat(response.getRelativePath()).isEqualTo("/file.txt");
+		MyFile file = fileRepository.findByOwnerNameAndFullPathAndStatus("testOwner",
+			"/hello/file.txt", FileItemStatus.SAVED).get();
+		assertThat(file).isNotNull();
+		assertThat(file.getFileName()).isEqualTo("file.txt");
+	}
+
+	@Test
+	@DisplayName("uploadFile: 공유 폴더 파일 업로드 정상 흐름")
+	@Transactional
+	void uploadFileInChildFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MyFolder world1 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world1", hello);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		UploadSharedFileRequestDto requestDto = new UploadSharedFileRequestDto(mockFile, sharedFolder.getSharedId(),
+			"/world1");
+
+		// when
+		SharedFolderItem response = sharedFolderService.uploadFile(requestDto);
+
+		entityManager.flush();
+
+		// then
+		assertThat(response.getSize()).isEqualTo(1);
+		assertThat(response.getName()).isEqualTo("file.txt");
+		assertThat(response.getType()).isEqualTo("File");
+		assertThat(response.getRelativePath()).isEqualTo("/world1/file.txt");
+
+		MyFile file = fileRepository.findByOwnerNameAndFullPathAndStatus("testOwner",
+			"/hello/world1/file.txt", FileItemStatus.SAVED).get();
+		assertThat(file).isNotNull();
+		assertThat(file.getFileName()).isEqualTo("file.txt");
+	}
+
+	@Test
+	@DisplayName("deleteFile: 공유 폴더의 파일 삭제 정상 흐름")
+	@Transactional
+	void deleteFile() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		// when
+		StringResponse response = sharedFolderService.deleteFile(sharedFolder.getSharedId(), "/file.txt");
+
+		// then
+		assertThat(response.getResponse()).isEqualTo("요청한 파일에 대한 삭제가 성공적으로 진행되었습니다.");
+		MyFile file = fileRepository.findByOwnerNameAndFullPathAndStatus("testOwner",
+			"/hello/file.txt", FileItemStatus.DELETED).get();
+		assertThat(file).isNotNull();
+		assertThat(file.getFileName()).isEqualTo("file.txt");
+	}
+
+	@Test
+	@DisplayName("deleteFile: 공유 폴더 하위의 폴더의 파일 삭제 정상 흐름")
+	@Transactional
+	void deleteFileInChildFolder() {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+		MyFolder world1 = folderRepositoryUtils.createAndPersistFolder("testOwner", "world1", hello);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", world1);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		// when
+		StringResponse response = sharedFolderService.deleteFile(sharedFolder.getSharedId(), "/world1/file.txt");
+
+		// then
+		assertThat(response.getResponse()).isEqualTo("요청한 파일에 대한 삭제가 성공적으로 진행되었습니다.");
+		MyFile file = fileRepository.findByOwnerNameAndFullPathAndStatus("testOwner",
+			"/hello/world1/file.txt", FileItemStatus.DELETED).get();
+		assertThat(file).isNotNull();
+		assertThat(file.getFileName()).isEqualTo("file.txt");
+	}
+
+	@Test
+	@DisplayName("downloadFile: 공유 폴더 파일 다운로드 정상흐름")
+	@Transactional
+	void downloadFile() throws IOException {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		// when
+		Resource resource = sharedFolderService.downloadFile(sharedFolder.getSharedId(), "/file.txt");
+
+		// then
+		assertThat(resource.getFilename().substring(37)).isEqualTo("file.txt");
+		assertThat(resource.contentLength()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("downloadFile: 공유 폴더 없는 파일 다운로드 오류")
+	@Transactional
+	void downloadFileFail() throws IOException {
+		// given
+		MyFolder root = folderRepositoryUtils.createAndPersistRootFolder("testOwner");
+		MyFolder hello = folderRepositoryUtils.createAndPersistFolder("testOwner", "hello", root);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file.txt", "file.txt", "text/plain", new byte[] {1});
+		MyFile myFile = fileRepositoryUtils.createAndPersistFile(mockFile, "testOwner", hello);
+		fileIoUtils.save(mockFile, myFile);
+
+		SharedFolder sharedFolder = sharedFolderUtils.createAndPersistSharedFolder(hello);
+
+		// when
+		RuntimeException exception = assertThrows(RuntimeException.class,
+			() -> sharedFolderService.downloadFile(sharedFolder.getSharedId(), "/file1.txt"));
+		// then
+		assertThat(exception.getMessage()).isEqualTo("잘못된 하위 파일에 대한 접근입니다.");
+	}
+
+	private void deleteDirectoryAndFiles(File targetFolder) {
+		File[] files = targetFolder.listFiles();
+		for (File file : files) {
+			if (file.isDirectory()) {
+				deleteDirectoryAndFiles(file);
+			}
+			file.delete();
+		}
+	}
+}


### PR DESCRIPTION
# Step 5

- [x] 파일/폴더 공유 링크 생성 API
- [x] 공유된 파일에 대한 API
- [x] 공유된 폴더에 대한 API

<br>

## 1.   파일/폴더 공유 링크 생성 API

파일이나 폴더의 공유 링크를 생성하는 API는 매우 간단하다.
파일이나 폴더의 UUID를 통해서 요청하고 공유 UUID를 제공 받는다.
- 파일 공유 링크 생성
	```
	Post /api/files/{fileUuid}/share
	```
- 폴더 공유 링크 생성
	```
	Post /api/folders/{folderUuid}/share
	```



<br>

---


## 2. 공유된 파일에 대한 API

파일에 대한 정보를 제공하고 파일을 다운로드 할 수 있는 기능만 제공하면 된다.

- 공유된 파일 정보 읽기
	```
	GET /api/share/files/{shareFileUuid}
	```

- 공유된 파일 다운로드
	```
	GET /api/share/files/{shareFileUuid}/download
	```

공유된 파일은 바로 공유UUID를 통해서 접근이 가능했기 때문에, 크게 다른 점은 없었다.

다만 소유자가 파일을 읽을 때는 절대 경로와 원본 UUID 등 가지고 있는 다양한 값을 제공하였는데,
공유된 파일에 대해서는 화면에 나타내기에 필수적인 요소만 제공한다.

<br>

---

## 3. 공유된 폴더에 대한 API

폴더를 공유했을 때는 공유를 받은 사람이 하위의 폴더와 파일에 대한 모든 권한을 갖는다. 
이전까지 **모든 파일/폴더에 대한 함수에 대한 접근을 자원을 명확하게 나타낼 수 있는 UUID로 처리**했다.

**공유된 폴더 하위의 파일과 폴더에 대해서 모두 공유 UUID를 만드는 것은 비효율적이며, 
원본 UUID를 공개하는 것도 별로 좋지 않다.**

DropBox를 참고했는데, 
**UUID를 통해서 공유된 폴더까지 접근하고 하위는 공유된 폴더 기준의 상대 경로로** 받아서 처리한다.
예시로 **/aaa**의 공유 UUID가 **xxxx-yyyy-zzz** 라면,  **xxxx-yyyy-zzz/bbb**로 **/aaa/bbb**에 접근한다.

아래의 **이 상대 경로를 나타내며, 없을 땐 공유 폴더 그 자체를 나타낸다.
- 폴더 정보 읽기
	```
	GET /api/share/folders/{sharedFolderId}/**
	```

- 파일 다운로드
	```
	GET /api/share/folders/download/{sharedFolderId}/** (파일에 접근해야하므로 **이 필수)
	```
- 파일 업로드
	```
	POST /api/share/folders/upload

	requestDto(MultipartFile multipartFile, UUID folderUuid, String relativePath) (relativePath로 폴더 지정)
	```
- 파일 삭제
	```
	DELETE /api/share/folders/{sharedFolderId}/** (파일에 접근해야하므로 **이 필수)
	```

<details>
	<summary>원본 UUID를 공개하지 않으려고 한 이유</summary>

	 - 이전에 공유한 UUID와 이번에 공유한 UUID가 다르고 각 공유는 제한 시간을 갖는다.
	 - 만약 원본 UUID를 제공한다면 이전에 공개되었던 원본 UUID통해 이번에도 접근할 수 있는 상황이 발생한다.
	 - 원본 UUID를 이용해 접근하는 것은 소유자의 권한으로 두고 싶었다. (물론 소유자 검사를 진행하지만, 노출되었을 때 노출되었을 때 좋을 것이 없다.)
	 - 구글 드라이브는 원본 UUID로 접근을 하도록 하며, 소유자가 열고 닫는 것을 관리하도록 하는데,
       이는 직관적이고 사용자들이 링크 복사를 통해 공유하는 일이 매우 빈번하기 때문인 것 같다. 
	
</details>


<br>

---

## 4. 함수의 재사용

이번 Step에서 구현한 부분은 공유라는 것만 제외하면 진행했던 구현과 거의 동일하다. 

그렇지만 함수를 많이 재사용 하지는 못했는데,
가장 큰 이유는 **사용자로부터 제공 받는 값과 사용자에게 제공해주어야 하는 값이 기존과 달랐기 때문**이다.

컨트롤러와 서비스 사이의 계층이 존재하고 서비스가 잘 모듈화가 되어있었다면 코드의 재사용이 가능했을 것 같다.
**(사용자로부터 제공 받는 값을 올바른 서비스의 입력으로 바꿔주고, 
서비스의 결과 값을 사용자가 받아야 할 값으로 바꿔주는 계층)**


**Step1 PR(#5)에 컨트롤러로의 입력과 서비스로의 입력을 분리하자는 언급을 했었다.**
그러나 프로젝트 진행하며 불필요한 코드가 많다고 생각해 그렇게 진행하지 않았다.
규모가 커지고 코드의 재사용의 가능성이 높아질 것을 고려하면 그 방식대로 설계하는 것이 옳았을 것이라 생각한다. 
(response 역시 XXXResonse와 XXXresponseDto로 분리)

<br>

> Dto을 어떻게 변환하고 이용할지 고민해왔는데, Controller와 Service 사이의 적절한 변환이 필요하다는 것을 배운 것 같다.